### PR TITLE
Bump SDK version to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circle-fin/circle-sdk",
-  "version": "0.1.0-alpha.0",
+  "version": "0.1.0-beta.0",
   "description": "Node.js SDK for Circle API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Beta version of SDK already published to npm: https://www.npmjs.com/package/@circle-fin/circle-sdk. This PR is just to keep Github repo package version in sync with the latest published version on npm.

[JIRA DEV-69](https://circlepay.atlassian.net/browse/DEV-69)