### PR TITLE
ci: add conventional commits check

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,19 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  commit_lint:
+    name: "Lint commit messages"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: yarn install --frozen-lockfile
+      - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
Added conventional commit pull request check which validates all the commit messages to be inline with https://www.conventionalcommits.org/en/v1.0.0/