### PR TITLE
ci: fix npm registry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://registry.npmjs.com/
+          registry-url: https://registry.npmjs.org/
       - run: yarn install --frozen-lockfile
       - run: yarn run build
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.com/
       - run: yarn install --frozen-lockfile
       - run: yarn run build
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/circlefin/circle-nodejs-sdk#readme",
   "publishConfig": {
-    "registry": "https://registry.npmjs.com/"
+    "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",


### PR DESCRIPTION
A bug discovered while troubleshooting AWS credentials issue in npm publish workflow with TechOps. Contributes to the workflow failing. 

Jira [DEV-165](https://circlepay.atlassian.net/browse/DEV-165)