### PR TITLE
ci: use github bot creds

### DIFF
--- a/.github/workflows/openapi-regen.yml
+++ b/.github/workflows/openapi-regen.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - sdk.json
 
+permissions:
+  id-token: write
+  contents: read
+
 env:
   OPENAPI_VER_FILE: OPENAPI_VERSION
   OPENAPI_FILE: sdk.json
@@ -31,6 +35,20 @@ jobs:
 
       - uses: actions/setup-node@v3
       - run: yarn install --frozen-lockfile
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID_PAY }}:role/github-actions-service-role
+
+      - name: Read secrets from AWS Secrets Manager into environment variables
+        uses: abhilash1in/aws-secrets-manager-action@v2.1.0
+        with:
+          parse-json: true
+          secrets: |
+            /ops/utilities/github-actions-bot/gpg-priv-key
+            /ops/utilities/github-actions-bot/api-token
 
       - name: Read openapi document
         id: read-openapi-doc
@@ -75,11 +93,25 @@ jobs:
         run: |
           echo "${{ steps.get-new-openapi-ver.outputs.version }}" > $OPENAPI_VER_FILE
 
+      - name: Import GPG key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ env._OPS_UTILITIES_GITHUB_ACTIONS_BOT_GPG_PRIV_KEY }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ env._OPS_UTILITIES_GITHUB_ACTIONS_BOT_API_TOKEN }}
           base: master
           branch: bot-openapi-regen-pr-v${{ steps.get-new-openapi-ver.outputs.version }}
+          
+          author: ${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>
+          committer: ${{ steps.import-gpg.outputs.name }} <${{ steps.import-gpg.outputs.email }}>
+          
           title: Regenerate code from OpenAPI document v${{ steps.get-new-openapi-ver.outputs.version }}
           commit-message: "${{ steps.get-conven-commit-pref.outputs.commit-pref }}: regen code openapi doc v${{ steps.get-new-openapi-ver.outputs.version }}"
           add-paths: |

--- a/.github/workflows/openapi-regen.yml
+++ b/.github/workflows/openapi-regen.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Read secrets from AWS Secrets Manager into environment variables
         uses: abhilash1in/aws-secrets-manager-action@v2.1.0
         with:
-          parse-json: true
           secrets: |
             /ops/utilities/github-actions-bot/gpg-priv-key
             /ops/utilities/github-actions-bot/api-token


### PR DESCRIPTION
Use TechOps created Github bot in actions. Solves below problems: 

1. commits generated from codegen workflow are unsigned / unverified
2. PR status checks not running automatically on codegen workflow-generated PRs 


Jira  [DEV-160](https://circlepay.atlassian.net/browse/DEV-160), [DEV-161](https://circlepay.atlassian.net/browse/DEV-161)