### PR TITLE
chore: gen sdk command cleanup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ dist
 node_modules
 templates
 coverage
+
+*.md

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Clone this repo and install dependencies using
 yarn install
 ```
 
-1. Run the codegen:
+1. Run the codegen command to generate the source code for this SDK from the `sdk.json` OpenAPI specification file:
 
     ```sh
     yarn gen-sdk

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ yarn install
 1. Run the codegen:
 
     ```sh
-    yarn gen-sdk <sdk-version>      # e.g. yarn gen-sdk 0.1.1-beta.0
+    yarn gen-sdk
     ```
 
 2. Run all tests:

--- a/build-utils/gen-sdk.sh
+++ b/build-utils/gen-sdk.sh
@@ -4,7 +4,7 @@ npx openapi-generator-cli generate -g typescript-axios  \
 -i sdk.json \
 -o ./src/generated/ \
 -p npmName=circle,supportsES6=true,modelPropertyNaming=original,apiPackage=apis,modelPackage=models \
--t ./templates/typescript-axios --additional-properties=npmVersion=$1,withSeparateModelsAndApi=true
+-t ./templates/typescript-axios --additional-properties=withSeparateModelsAndApi=true
 
 npx ts-node build-utils/mustache-camelize.ts src/generated/index.ts > src/generated/index-temp.ts
 


### PR DESCRIPTION
Following changes made in this PR

1. Make prettier command ignore Markdown files so that they don't change every time `yarn gen-sdk` is run
2. Remove version command line argument from `yarn gen-sdk`. It a deprecated argument as of #47 
3. Add a clearer description of in `README.md` for the `yarn gen-sdk` command to avoid confusion (see https://github.com/circlefin/circle-nodejs-sdk/issues/52)