### PR TITLE
ci: fix ID token perms

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,7 @@ on: [workflow_dispatch, workflow_call]
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
Restore `id-token: write` in the reusable npm publish workflow so AWS OIDC auth works during publish

### Why
- the publish pipeline is failing in `Configure AWS Credentials` before `npm publish`
- `aws-actions/configure-aws-credentials` is using `role-to-assume`, which requires a GitHub OIDC token
- the workflow only grants `contents: read`, so the job cannot mint that token

## Details

### Regression Context
- `id-token: write` was originally added in [`ffcaf51`](https://github.com/circlefin/circle-nodejs-sdk/commit/ffcaf5123b4c6819faa0e3a4ca1e440bfead4161) (`fix: allow OIDC token in publish pipeline (#25)`)
- it was removed in [`40ee83f`](https://github.com/circlefin/circle-nodejs-sdk/commit/40ee83f401692bfece44c34f4ad666ddff7d5751) (`chore(stepsecurity): update workflows to use custom hosted runners with built-in StepSecurity (#133)`)
- that regression stayed hidden until [`27f4efe`](https://github.com/circlefin/circle-nodejs-sdk/commit/27f4efec1769dcc5507cb4b80798cf4e3b5af9cc) (`ci: fix release-please wiring (#140)`) fixed release gating and caused `npm-publish` to run again

## Validation
- reviewed failed run [`23300901189`](https://github.com/circlefin/circle-nodejs-sdk/actions/runs/23300901189) and failing job [`67761702334`](https://github.com/circlefin/circle-nodejs-sdk/actions/runs/23300901189/job/67761702334)
- confirmed the job fails in `Configure AWS Credentials` with the log: `Did you mean to set the id-token permission?`